### PR TITLE
Contextual Errors

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -34,6 +34,7 @@ const router = createBrowserRouter([
       {
         path:"contacts/:contactId/destroy",
         action: destroyAction,
+        errorElement: <div> Oops! There was an error. 🤯</div>,
       },
     ],
   },

--- a/src/routes/destroy.jsx
+++ b/src/routes/destroy.jsx
@@ -2,6 +2,7 @@ import { redirect } from "react-router-dom";
 import { deleteContact } from "../contacts";
 
 export async function action({ params }) {
+  throw new Error("oh dang!");
   await deleteContact(params.contactId);
   return redirect("/");
 }


### PR DESCRIPTION
Just for kicks, throw an error in the destroy action
![image](https://user-images.githubusercontent.com/99068989/224682946-7a8246ac-22f8-46ea-8fae-1b7329ab1ede.png)
 - Recognize that screen? It's our [errorElement](https://reactrouter.com/en/main/route/error-element) from before. The user, however, can't really do anything to recover from this screen except to hit refresh.

create a contextual error message for the destroy route:
 - 
![image](https://user-images.githubusercontent.com/99068989/224683135-d73a9784-1703-4b5b-8076-4171f2ebb1cf.png)
 - Our user now has more options than slamming refresh, they can continue to interact with the parts of the page that aren't having trouble 🙌

Because the destroy route has its own errorElement and is a child of the root route, the error will render there instead of the root. As you probably noticed, these errors bubble up to the nearest errorElement. Add as many or as few as you like, as long as you've got one at the root.
