### PR TITLE
Cancel Button

### DIFF
--- a/src/routes/edit.jsx
+++ b/src/routes/edit.jsx
@@ -1,4 +1,4 @@
-import { Form, useLoaderData, redirect,} from "react-router-dom";
+import { Form, useLoaderData, redirect, useNavigate,} from "react-router-dom";
 import { updateContact } from "../contacts";
 
 // Without JavaScript, when a form is submitted, the browser will create FormData and set it as the body of the request when it sends it to the server. 
@@ -19,7 +19,7 @@ export async function action({ request, params }) {
 
 export default function EditContact() {
   const contact = useLoaderData();
-
+  const navigate = useNavigate();
   return (
     <Form method="post" id="contact-form">
       <p>
@@ -68,7 +68,9 @@ export default function EditContact() {
       </label>
       <p>
         <button type="submit">Save</button>
-        <button type="button">Cancel</button>
+        <button type="button" onClick={()=>{
+          navigate(-1);
+        }} >Cancel</button>
       </p>
     </Form>
   );


### PR DESCRIPTION
On the edit page we've got a cancel button that doesn't do anything yet. We'd like it to do the same thing as the browser's back button.

We'll need a click handler on the button as well as [useNavigate](https://reactrouter.com/en/main/hooks/use-navigate) from React Router.

👉 Add the cancel button click handler with `useNavigate`

Now when the user clicks "Cancel", they'll be sent back one entry in the browser's history.

🧐 Why is there no `event.preventDefault` on the button?

A `<button type="button">`, while seemingly redundant, is the HTML way of preventing a button from submitting its form.

