### PR TITLE
Submitting Forms `onChange`

### DIFF
--- a/src/routes/root.jsx
+++ b/src/routes/root.jsx
@@ -1,5 +1,5 @@
 // Create the root layout component
-import { Outlet, NavLink, Link, useLoaderData, Form, redirect, useNavigation} from "react-router-dom";
+import { Outlet, NavLink, Link, useLoaderData, Form, redirect, useNavigation, useSubmit,} from "react-router-dom";
 import { useEffect } from "react";
 import { getContacts, createContact} from "../contacts";
 
@@ -20,6 +20,7 @@ export default function Root(){
 
     const {contacts,q} = useLoaderData();
     const navigation = useNavigation();
+    const submit = useSubmit();
 
     useEffect(() => {
       document.getElementById("q").value = q;
@@ -34,7 +35,14 @@ export default function Root(){
             <div>
                 <Form id="search-form" role="search">
 
-                    <input id="q" arial-label="Search contacts" placeholder="Search In Contacts" type="search" name="q" defaultValue={q} />
+                    <input id="q" arial-label="Search contacts" 
+                       placeholder="Search In Contacts" type="search" name="q" 
+                       defaultValue={q}
+                       onChange={(event) => {
+                        submit(event.currentTarget.form);
+                      }}
+                      
+                    />
                     <div id="search-spinner" aria-hidden hidden ={true} />
                     <div className="sr-only" aria-alive="polite"> </div>
                 </Form>


### PR DESCRIPTION
We've got a product decision to make here. For this UI, we'd probably rather have the filtering happen on every key stroke instead of when the form is explicitly submitted.
- We've seen useNavigate already, we'll use its cousin, useSubmit, for this.
 
- Now as you type, the form is submitted automatically!
![image](https://user-images.githubusercontent.com/99068989/224702413-aed7a8a3-f057-4fd8-bb21-6f8f6e617ca3.png)


Note the argument to [submit](https://reactrouter.com/en/main/hooks/use-submit). We're passing in event.currentTarget.form. The currentTarget is the DOM node the event is attached to, and the currentTarget.form is the input's parent form node. The submit function will serialize and submit any form you pass to it.