### PR TITLE
👉 Add the search spinner

### DIFF
--- a/src/routes/root.jsx
+++ b/src/routes/root.jsx
@@ -22,6 +22,8 @@ export default function Root(){
     const navigation = useNavigation();
     const submit = useSubmit();
 
+    const searching = navigation.location && new URLSearchParams(navigation.location.search).has("q")
+
     useEffect(() => {
       document.getElementById("q").value = q;
     }, [q]);
@@ -35,7 +37,7 @@ export default function Root(){
             <div>
                 <Form id="search-form" role="search">
 
-                    <input id="q" arial-label="Search contacts" 
+                    <input id="q" className={searching ? "loading" : ""} arial-label="Search contacts" 
                        placeholder="Search In Contacts" type="search" name="q" 
                        defaultValue={q}
                        onChange={(event) => {
@@ -43,7 +45,7 @@ export default function Root(){
                       }}
                       
                     />
-                    <div id="search-spinner" aria-hidden hidden ={true} />
+                    <div id="search-spinner" aria-hidden hidden ={!searching} />
                     <div className="sr-only" aria-alive="polite"> </div>
                 </Form>
 


### PR DESCRIPTION
In a production app, it's likely this search will be looking for records in a database that is too large to send all at once and filter client side. That's why this demo has some faked network latency.

Without any loading indicator, the search feels kinda sluggish. Even if we could make our database faster, we'll always have the user's network latency in the way and out of our control. For a better UX, let's add some immediate UI feedback for the search. For this we'll use useNavigation again.

![image](https://user-images.githubusercontent.com/99068989/224703986-fdd71690-b982-4a5d-a89e-46fd2c326e18.png)

- The `navigation.location` will show up when the app is navigating to a new URL and loading the data for it. It then goes away when there is no pending navigation anymore.
