### PR TITLE
👉 Use replace in submit

### DIFF
--- a/src/routes/root.jsx
+++ b/src/routes/root.jsx
@@ -41,7 +41,10 @@ export default function Root(){
                        placeholder="Search In Contacts" type="search" name="q" 
                        defaultValue={q}
                        onChange={(event) => {
-                        submit(event.currentTarget.form);
+                        const isFirstSearch = q == null;
+                        submit(event.currentTarget.form,{
+                          replace: !isFirstSearch,
+                        });
                       }}
                       
                     />


### PR DESCRIPTION
Now that the form is submitted for every key stroke, if we type the characters "seba" and then delete them with backspace, we end up with 7 new entries in the stack 😂. We definitely don't want this.

![image](https://user-images.githubusercontent.com/99068989/224705349-d89816ea-540f-462d-8975-eb955da96444.png)

We can avoid this by replacing the current entry in the history stack with the next page, instead of pushing into it.
We only want to replace search results, not the page before we started searching, so we do a quick check if this is the first search or not and then decide to replace.

Each key stroke no longer creates new entries, so the user can click back out of the search results without having to click it 7 times 😅.
