### PR TITLE
Star btn -Mutations Without Navigation

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@ import  React from 'react';
 import Root from "./routes/root";
 import ReactDOM from 'react-dom/client';
 import ErrorPage from "./error-page";
-import Contact,{loader as contactLoader,} from "./routes/contact";
+import Contact,{loader as contactLoader,action as contactAction,} from "./routes/contact";
 import {loader as rootLoader, action as rootAction,} from "./routes/root";
 import EditContact, { action as editAction,} from "./routes/edit";
 import { createBrowserRouter,RouterProvider,} from "react-router-dom";
@@ -26,6 +26,7 @@ const router = createBrowserRouter([
         path: "contacts/:contactId",
         element: <Contact />,
         loader: contactLoader,
+        action: contactAction,
       },
       {
         path: "contacts/:contactId/edit",

--- a/src/routes/contact.jsx
+++ b/src/routes/contact.jsx
@@ -1,9 +1,16 @@
-import { Form, useLoaderData } from "react-router-dom";
-import { getContact } from "../contacts";
+import { Form, useLoaderData, useFetcher,} from "react-router-dom";
+import { getContact, updateContact } from "../contacts";
 
 export async function loader({ params }) {
   const contact = await getContact(params.contactId);
   return { contact };
+}
+
+export async function action({ request, params }) {
+  let formData = await request.formData();
+  return updateContact(params.contactId, {
+    favorite: formData.get("favorite") === "true",
+  });
 }
 
 export default function Contact() {
@@ -80,9 +87,10 @@ export default function Contact() {
 
 function Favorite({ contact }) {
   // yes, this is a `let` for later
+  const fetcher = useFetcher();
   let favorite = contact.favorite;
   return (
-    <Form method="post">
+    <fetcher.Form method="post">
       <button
         name="favorite"
         value={favorite ? "false" : "true"}
@@ -94,6 +102,6 @@ function Favorite({ contact }) {
       >
         {favorite ? "★" : "☆"}
       </button>
-    </Form>
+    </fetcher.Form>
   );
 }


### PR DESCRIPTION
So far all of our mutations (the times we change data) have used forms that navigate, creating new entries in the history stack. While these user flows are common, it's equally as common to want to change data without causing a navigation.

For these cases, we have the [useFetcher](https://reactrouter.com/en/main/hooks/use-fetcher) hook. It allows us to communicate with loaders and actions without causing a navigation.

The ★ button on the contact page makes sense for this. We aren't creating or deleting a new record, we don't want to change pages, we simply want to change the data on the page we're looking at.
- 👉 Change the <Favorite> form to a fetcher form
- 👉 Create the action
- 👉 Configure the route's new action

**Alright, we're ready to click the star next to the user's name!**
![image](https://user-images.githubusercontent.com/99068989/224709181-4ec61eb9-8d42-42b7-bd88-fdd8008c3215.png)

Check that out, both stars automatically update. Our new <fetcher.Form method="post"> works almost exactly like a the <Form> we've been using: it calls the action and then all data is revalidated automatically--even your errors will be caught the same way.

There is one key difference though, it's not a navigation--the URL doesn't change, the history stack is unaffected.
