### PR TITLE
👉 Throw a 404 response in the loader

### DIFF
--- a/src/routes/contact.jsx
+++ b/src/routes/contact.jsx
@@ -3,6 +3,12 @@ import { getContact, updateContact } from "../contacts";
 
 export async function loader({ params }) {
   const contact = await getContact(params.contactId);
+  if (!contact) {
+    throw new Response("", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
   return { contact };
 }
 


### PR DESCRIPTION
What happens if the contact we're trying to load doesn't exist?

![image](https://user-images.githubusercontent.com/99068989/224711278-decef6b2-981f-43d8-a6c5-feb26bf34f52.png)

Our root [errorElement](https://reactrouter.com/en/main/route/error-element) is catching this unexpected error as we try to render a null contact. Nice the error was properly handled, but we can do better!

Whenever you have an expected error case in a loader or action–like the data not existing–you can `throw`. The call stack will break, React Router will catch it, and the error path is rendered instead. We won't even try to render a `null` contact.
- 👉 Throw a 404 response in the loader
![image](https://user-images.githubusercontent.com/99068989/224711487-4d192110-5e05-420b-aa84-79d5dc2963dd.png)

Instead of hitting a render error with `Cannot read properties` of `null`, we avoid the component completely and render the error path instead, telling the user something more specific.

This keeps your happy paths, happy. Your route elements don't need to concern themselves with error and loading states.

