### PR TITLE
Pathless Routes

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -21,12 +21,19 @@ const router = createBrowserRouter([
     loader: rootLoader,
     action: rootAction,
     children:[
-      { index: true, element: <Index/>},
+      
       {
-        path: "contacts/:contactId",
-        element: <Contact />,
-        loader: contactLoader,
-        action: contactAction,
+        errorElement: <ErrorPage/>,
+        children: [
+          { index: true, element: <Index/>},
+          {
+            path: "contacts/:contactId",
+            element: <Contact />,
+            loader: contactLoader,
+            action: contactAction,
+          },
+
+        ]
       },
       {
         path: "contacts/:contactId/edit",


### PR DESCRIPTION
The last error page we saw would be better if it rendered inside the root outlet, instead of the whole page. In fact, every error in all of our child routes would be better in the outlet, then the user has more options than hitting refresh.

We'd like it to look like this:
![image](https://user-images.githubusercontent.com/99068989/224713063-bd39a7fa-a4c5-484a-9c65-3650510e18ef.png)

We could add the error element to every one of the child routes but, since it's all the same error page, this isn't recommended.

There's a cleaner way. Routes can be used without a path, which lets them participate in the UI layout without requiring new path segments in the URL. Check it out:

👉 Wrap the child routes in a pathless route
When any errors are thrown in the child routes, our new pathless route will catch it and render, preserving the root route's UI!
